### PR TITLE
Create # Rozpoczęcie fazy rozwoju

### DIFF
--- a/# Rozpoczęcie fazy rozwoju
def create_multilingual_code():
    languages = ['Python', 'JavaScript', 'C++', 'Rust', 'Go']
    print("Integracja języków: ", languages)

    # Przykład działania w Pythonie
    def python_example():
        return "Kod Pythona uruchomiony 🚀"
    
    # Przykład działania w JavaScript
    js_example = lambda: "Kod JavaScript uruchomiony 🌐"
    
    # Wywołanie funkcji
    print(python_example())
    print(js_example())

create_multilingual_code()
+++ b/# Rozpoczęcie fazy rozwoju
def create_multilingual_code():
    languages = ['Python', 'JavaScript', 'C++', 'Rust', 'Go']
    print("Integracja języków: ", languages)

    # Przykład działania w Pythonie
    def python_example():
        return "Kod Pythona uruchomiony 🚀"
    
    # Przykład działania w JavaScript
    js_example = lambda: "Kod JavaScript uruchomiony 🌐"
    
    # Wywołanie funkcji
    print(python_example())
    print(js_example())

create_multilingual_code()
@@ -1,0 +1,23 @@
+# Rozpoczęcie interaktywnego systemu
+import time
+
+def interactive_system():
+    print("🚀 System dynamicznych aktualizacji uruchomiony!")
+    
+    # Funkcja obsługi emotikon
+    def handle_emojis(emoji):
+        responses = {
+            "🚀": "Przyspieszenie systemu!",
+            "♾️": "Nieskończone możliwości aktywne!",
+            "📜": "Wyświetlanie bieżących zmian kodu!",
+            "✨": "Optymalizacja zakończona sukcesem!"
+        }
+        return responses.get(emoji, "Emotka nieznana.")
+
+    # Symulacja interakcji
+    for emoji in ["🚀", "♾️", "📜", "✨"]:
+        response = handle_emojis(emoji)
+        print(f"Emotka: {emoji}, Akcja: {response}")
+        time.sleep(1)
+
+interactive_system()


### PR DESCRIPTION
def create_multilingual_code():
    languages = ['Python', 'JavaScript', 'C++', 'Rust', 'Go']
    print("Integracja języków: ", languages)

    # Przykład działania w Pythonie
    def python_example():
        return "Kod Pythona uruchomiony 🚀"
    
    # Przykład działania w JavaScript
    js_example = lambda: "Kod JavaScript uruchomiony 🌐"
    
    # Wywołanie funkcji
    print(python_example())
    print(js_example())

create_multilingual_code()Correlation Id: ab0aa980-93b9-4931-84be-8fe3435f7a0e
Timestamp: 2025-04-24T14:59:39.000Z
DPTI: e09cb827ae5cee5a
Message: An unexpected error occurred.
Tag: 5a2pe
Code: 0$ git checkout -b <branch> --track <remote>/<branch>
You could omit <branch>, in which case the command degenerates to "check out the current branch", which is a glorified no-op with rather expensive side-effects to show only the tracking information, if it exists, for the current branch.

git checkout -b|-B <new-branch> [<start-point>]
Specifying -b causes a new branch to be created as if git-branch[1] were called and then checked out. In this case you can use the --track or --no-track options, which will be passed to git branch. As a convenience, --track without -b implies branch creation; see the description of --track below.

If -B is given, <new-branch> is created if it doesn’t exist; otherwise, it is reset. This is the transactional equivalent of

$ git branch -f <branch> [<start-point>]
$ git checkout <branch>
that is to say, the branch is not reset/created unless "git checkout" is successful (e.g., when the branch is in use in another worktree, not just the current branch stays the same, but the branch is not reset to the start-point, either).

git checkout --detach [<branch>]
git checkout [--detach] <commit>
Prepare to work on top of <commit>, by detaching HEAD at it (see "DETACHED HEAD" section), and updating the index and the files in the working tree. Local modifications to the files in the working tree are kept, so that the resulting working tree will be the state recorded in the commit plus the local modifications.

When the <commit> argument is a branch name, the --detach option can be used to detach HEAD at the tip of the branch (git checkout <branch> would check out that branch without detaching HEAD).

Omitting <branch> detaches HEAD at the tip of the current branch.

git checkout [-f|--ours|--theirs|-m|--conflict=<style>] [<tree-ish>] [--] <pathspec>…​
git checkout [-f|--ours|--theirs|-m|--conflict=<style>] [<tree-ish>] --pathspec-from-file=<file> [--pathspec-file-nul]
Overwrite the contents of the files that match the pathspec. When the <tree-ish> (most often a commit) is not given, overwrite working tree with the contents in the index. When the <tree-ish> is given, overwrite both the index and the working tree with the contents at the <tree-ish>.

The index may contain unmerged entries because of a previous failed merge. By default, if you try to check out such an entry from the index, the checkout operation will fail and nothing will be checked out. Using -f will ignore these unmerged entries. The contents from a specific side of the merge can be checked out of the index by using --ours or --theirs. With -m, changes made to the working tree file can be discarded to re-create the original conflicted merge result.

git checkout (-p|--patch) [<tree-ish>] [--] [<pathspec>…​]
This is similar to the previous mode, but lets you use the interactive interface to show the "diff" output and choose which hunks to use in the result. See below for the description of --patch option.

OPTIONS
-q
--quiet
Quiet, suppress feedback messages.

--progress
--no-progress
Progress status is reported on the standard error stream by default when it is attached to a terminal, unless --quiet is specified. This flag enables progress reporting even if not attached to a terminal, regardless of --quiet.

-f
--force
When switching branches, proceed even if the index or the working tree differs from HEAD, and even if there are untracked files in the way. This is used to throw away local changes and any untracked files or directories that are in the way.

When checking out paths from the index, do not fail upon unmerged entries; instead, unmerged entries are ignored.

--ours
--theirs
When checking out paths from the index, check out stage #2 (ours) or #3 (theirs) for unmerged paths.

Note that during git rebase and git pull --rebase, ours and theirs may appear swapped; --ours gives the version from the branch the changes are rebased onto, while --theirs gives the version from the branch that holds your work that is being rebased.

This is because rebase is used in a workflow that treats the history at the remote as the shared canonical one, and treats the work done on the branch you are rebasing as the third-party work to be integrated, and you are temporarily assuming the role of the keeper of the canonical history during the rebase. As the keeper of the canonical history, you need to view the history from the remote as ours (i.e. "our shared canonical history"), while what you did on your side branch as theirs (i.e. "one contributor’s work on top of it").

-b <new-branch>
Create a new branch named <new-branch>, start it at <start-point>, and check the resulting branch out; see git-branch[1] for details.

-B <new-branch>
Creates the branch <new-branch>, start it at <start-point>; if it already exists, then reset it to <start-point>. And then check the resulting branch out. This is equivalent to running "git branch" with "-f" followed by "git checkout" of that branch; see git-branch[1] for details.

-t
--track[=(direct|inherit)]
When creating a new branch, set up "upstream" configuration. See "--track" in git-branch[1] for details.

If no -b option is given, the name of the new branch will be derived from the remote-tracking branch, by looking at the local part of the refspec configured for the corresponding remote, and then stripping the initial part up to the "*". This would tell us to use hack as the local branch when branching off of origin/hack (or remotes/origin/hack, or even refs/remotes/origin/hack). If the given name has no slash, or the above guessing results in an empty name, the guessing is aborted. You can explicitly give a name with -b in such a case.

--no-track
Do not set up "upstream" configuration, even if the branch.autoSetupMerge configuration variable is true.

--guess
--no-guess
If <branch> is not found but there does exist a tracking branch in exactly one remote (call it <remote>) with a matching name, treat as equivalent to

$ git checkout -b <branch> --track <remote>/<branch>
If the branch exists in multiple remotes and one of them is named by the checkout.defaultRemote configuration variable, we’ll use that one for the purposes of disambiguation, even if the <branch> isn’t unique across all remotes. Set it to e.g. checkout.defaultRemote=origin to always checkout remote branches from there if <branch> is ambiguous but exists on the origin remote. See also checkout.defaultRemote in git-config[1].

--guess is the default behavior. Use --no-guess to disable it.

The default behavior can be set via the checkout.guess configuration variable.

-l
Create the new branch’s reflog; see git-branch[1] for details.

-d
--detach
Rather than checking out a branch to work on it, check out a commit for inspection and discardable experiments. This is the default behavior of git checkout <commit> when <commit> is not a branch name. See the "DETACHED HEAD" section below for details.

--orphan <new-branch>
Create a new unborn branch, named <new-branch>, started from <start-point> and switch to it. The first commit made on this new branch will have no parents and it will be the root of a new history totally disconnected from all the other branches and commits.

The index and the working tree are adjusted as if you had previously run git checkout <start-point>. This allows you to start a new history that records a set of paths similar to <start-point> by easily running git commit -a to make the root commit.

This can be useful when you want to publish the tree from a commit without exposing its full history. You might want to do this to publish an open source branch of a project whose current tree is "clean", but whose full history contains proprietary or otherwise encumbered bits of code.

If you want to start a disconnected history that records a set of paths that is totally different from the one of <start-point>, then you should clear the index and the working tree right after creating the orphan branch by running git rm -rf . from the top level of the working tree. Afterwards you will be ready to prepare your new files, repopulating the working tree, by copying them from elsewhere, extracting a tarball, etc.

--ignore-skip-worktree-bits
In sparse checkout mode, git checkout -- <paths> would update only entries matched by <paths> and sparse patterns in $GIT_DIR/info/sparse-checkout. This option ignores the sparse patterns and adds back any files in <paths>.

-m
--merge
When switching branches, if you have local modifications to one or more files that are different between the current branch and the branch to which you are switching, the command refuses to switch branches in order to preserve your modifications in context. However, with this option, a three-way merge between the current branch, your working tree contents, and the new branch is done, and you will be on the new branch.

When a merge conflict happens, the index entries for conflicting paths are left unmerged, and you need to resolve the conflicts and mark the resolved paths with git add (or git rm if the merge should result in deletion of the path).

When checking out paths from the index, this option lets you recreate the conflicted merge in the specified paths. This option cannot be used when checking out paths from a tree-ish.

When switching branches with --merge, staged changes may be lost.

--conflict=<style>
The same as --merge option above, but changes the way the conflicting hunks are presented, overriding the merge.conflictStyle configuration variable. Possible values are "merge" (default), "diff3", and "zdiff3".

-p
--patch
Interactively select hunks in the difference between the <tree-ish> (or the index, if unspecified) and the working tree. The chosen hunks are then applied in reverse to the working tree (and if a <tree-ish> was specified, the index).

This means that you can use git checkout -p to selectively discard edits from your current working tree. See the “Interactive Mode” section of git-add[1] to learn how to operate the --patch mode.

Note that this option uses the no overlay mode by default (see also --overlay), and currently doesn’t support overlay mode.

--ignore-other-worktrees
git checkout refuses when the wanted branch is already checked out or otherwise in use by another worktree. This option makes it check the branch out anyway. In other words, the branch can be in use by more than one worktree.

--overwrite-ignore
--no-overwrite-ignore
Silently overwrite ignored files when switching branches. This is the default behavior. Use --no-overwrite-ignore to abort the operation when the new branch contains ignored files.

--recurse-submodules
--no-recurse-submodules
Using --recurse-submodules will update the content of all active submodules according to the commit recorded in the superproject. If local modifications in a submodule would be overwritten the checkout will fail unless -f is used. If nothing (or --no-recurse-submodules) is used, submodules working trees will not be updated. Just like git-submodule[1], this will detach HEAD of the submodule.

--overlay
--no-overlay
In the default overlay mode, git checkout never removes files from the index or the working tree. When specifying --no-overlay, files that appear in the index and working tree, but not in <tree-ish> are removed, to make them match <tree-ish> exactly.

--pathspec-from-file=<file>
Pathspec is passed in <file> instead of commandline args. If <file> is exactly - then standard input is used. Pathspec elements are separated by LF or CR/LF. Pathspec elements can be quoted as explained for the configuration variable core.quotePath (see git-config[1]). See also --pathspec-file-nul and global --literal-pathspecs.

--pathspec-file-nul
Only meaningful with --pathspec-from-file. Pathspec elements are separated with NUL character and all other characters are taken literally (including newlines and quotes).

<branch>
Branch to checkout; if it refers to a branch (i.e., a name that, when prepended with "refs/heads/", is a valid ref), then that branch is checked out. Otherwise, if it refers to a valid commit, your HEAD becomes "detached" and you are no longer on any branch (see below for details).

You can use the @{-N} syntax to refer to the N-th last branch/commit checked out using "git checkout" operation. You may also specify - which is synonymous to @{-1}.

As a special case, you may use A...B as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD.

<new-branch>
Name for the new branch.

<start-point>
The name of a commit at which to start the new branch; see git-branch[1] for details. Defaults to HEAD.

As a special case, you may use "A...B" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD.

<tree-ish>
Tree to checkout from (when paths are given). If not specified, the index will be used.

As a special case, you may use "A...B" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD.

--
Do not interpret any more arguments as options.

<pathspec>…​
Limits the paths affected by the operation.

For more details, see the pathspec entry in gitglossary[7].

DETACHED HEAD
HEAD normally refers to a named branch (e.g. master). Meanwhile, each branch refers to a specific commit. Let’s look at a repo with three commits, one of them tagged, and with branch master checked out:

           HEAD (refers to branch 'master')
            |
            v
a---b---c  branch 'master' (refers to commit 'c')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
When a commit is created in this state, the branch is updated to refer to the new commit. Specifically, git commit creates a new commit d, whose parent is commit c, and then updates branch master to refer to new commit d. HEAD still refers to branch master and so indirectly now refers to commit d:

$ edit; git add; git commit

               HEAD (refers to branch 'master')
                |
                v
a---b---c---d  branch 'master' (refers to commit 'd')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
It is sometimes useful to be able to checkout a commit that is not at the tip of any named branch, or even to create a new commit that is not referenced by a named branch. Let’s look at what happens when we checkout commit b (here we show two ways this may be done):

$ git checkout v2.0  # or
$ git checkout master^^

   HEAD (refers to commit 'b')
    |
    v
a---b---c---d  branch 'master' (refers to commit 'd')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
Notice that regardless of which checkout command we use, HEAD now refers directly to commit b. This is known as being in detached HEAD state. It means simply that HEAD refers to a specific commit, as opposed to referring to a named branch. Let’s see what happens when we create a commit:

$ edit; git add; git commit

     HEAD (refers to commit 'e')
      |
      v
      e
     /
a---b---c---d  branch 'master' (refers to commit 'd')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
There is now a new commit e, but it is referenced only by HEAD. We can of course add yet another commit in this state:

$ edit; git add; git commit

	 HEAD (refers to commit 'f')
	  |
	  v
      e---f
     /
a---b---c---d  branch 'master' (refers to commit 'd')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
In fact, we can perform all the normal Git operations. But, let’s look at what happens when we then checkout master:

$ git checkout master

               HEAD (refers to branch 'master')
      e---f     |
     /          v
a---b---c---d  branch 'master' (refers to commit 'd')
    ^
    |
  tag 'v2.0' (refers to commit 'b')
It is important to realize that at this point nothing refers to commit f. Eventually commit f (and by extension commit e) will be deleted by the routine Git garbage collection process, unless we create a reference before that happens. If we have not yet moved away from commit f, any of these will create a reference to it:

$ git checkout -b foo  # or "git switch -c foo"  (1)
$ git branch foo                                 (2)
$ git tag foo                                    (3)
creates a new branch foo, which refers to commit f, and then updates HEAD to refer to branch foo. In other words, we’ll no longer be in detached HEAD state after this command.

similarly creates a new branch foo, which refers to commit f, but leaves HEAD detached.

creates a new tag foo, which refers to commit f, leaving HEAD detached.

If we have moved away from commit f, then we must first recover its object name (typically by using git reflog), and then we can create a reference to it. For example, to see the last two commits to which HEAD referred, we can use either of these commands:

$ git reflog -2 HEAD # or
$ git log -g -2 HEAD
ARGUMENT DISAMBIGUATION
When there is only one argument given and it is not -- (e.g. git checkout abc), and when the argument is both a valid <tree-ish> (e.g. a branch abc exists) and a valid <pathspec> (e.g. a file or a directory whose name is "abc" exists), Git would usually ask you to disambiguate. Because checking out a branch is so common an operation, however, git checkout abc takes "abc" as a <tree-ish> in such a situation. Use git checkout -- <pathspec> if you want to checkout these paths out of the index.

EXAMPLES
1. Paths
The following sequence checks out the master branch, reverts the Makefile to two revisions back, deletes hello.c by mistake, and gets it back from the index.

$ git checkout master             (1)
$ git checkout master~2 Makefile  (2)
$ rm -f hello.c
$ git checkout hello.c            (3)
switch branch

take a file out of another commit

restore hello.c from the index

If you want to check out all C source files out of the index, you can say

$ git checkout -- '*.c'
Note the quotes around *.c. The file hello.c will also be checked out, even though it is no longer in the working tree, because the file globbing is used to match entries in the index (not in the working tree by the shell).

If you have an unfortunate branch that is named hello.c, this step would be confused as an instruction to switch to that branch. You should instead write:

$ git checkout -- hello.c
2. Merge
After working in the wrong branch, switching to the correct branch would be done using:

$ git checkout mytopic
However, your "wrong" branch and correct mytopic branch may differ in files that you have modified locally, in which case the above checkout would fail like this:

$ git checkout mytopic
error: You have local changes to 'frotz'; not switching branches.
You can give the -m flag to the command, which would try a three-way merge:

$ git checkout -m mytopic
Auto-merging frotz
After this three-way merge, the local modifications are not registered in your index file, so git diff would show you what changes you made since the tip of the new branch.

3. Merge conflict
When a merge conflict happens during switching branches with the -m option, you would see something like this:

$ git checkout -m mytopic
Auto-merging frotz
ERROR: Merge conflict in frotz
fatal: merge program failed
At this point, git diff shows the changes cleanly merged as in the previous example, as well as the changes in the conflicted files. Edit and resolve the conflict and mark it resolved with git add as usual:

$ edit frotz
$ git add frotz
CONFIGURATION
Everything below this line in this section is selectively included from the git-config[1] documentation. The content is the same as what’s found there:

checkout.defaultRemote
When you run git checkout <something> or git switch <something> and only have one remote, it may implicitly fall back on checking out and tracking e.g. origin/<something>. This stops working as soon as you have more than one remote with a <something> reference. This setting allows for setting the name of a preferred remote that should always win when it comes to disambiguation. The typical use-case is to set this to origin.

Currently this is used by git-switch[1] and git-checkout[1] when git checkout <something> or git switch <something> will checkout the <something> branch on another remote, and by git-worktree[1] when git worktree add refers to a remote branch. This setting might be used for other checkout-like commands or functionality in the future.

checkout.guess
Provides the default value for the --guess or --no-guess option in git checkout and git switch. See git-switch[1] and git-checkout[1].

checkout.workers
The number of parallel workers to use when updating the working tree. The default is one, i.e. sequential execution. If set to a value less than one, Git will use as many workers as the number of logical cores available. This setting and checkout.thresholdForParallelism affect all commands that perform checkout. E.g. checkout, clone, reset, sparse-checkout, etc.

Note: Parallel checkout usually delivers better performance for repositories located on SSDs or over NFS. For repositories on spinning disks and/or machines with a small number of cores, the default sequential checkout often performs better. The size and compression level of a repository might also influence how well the parallel version performs.

checkout.thresholdForParallelism
When running parallel checkout with a small number of files, the cost of subprocess spawning and inter-process communication might outweigh the parallelization gains. This setting allows you to define the minimum number of files for which parallel checkout should be attempted. The default is 100.

SEE ALSO
git-switch[1], git-restore[1]

GIT
Part of the git[1] suite

Please help me generate a work report. My work progress is as follows: The AI product project has just started, and the research phase has been completed. The next step is to allocate development resources..# Rozpoczęcie fazy rozwoju
def create_multilingual_code():
    languages = ['Python', 'JavaScript', 'C++', 'Rust', 'Go']
    print("Integracja języków: ", languages)

    # Przykład działania w Pythonie
    def python_example():
        return "Kod Pythona uruchomiony 🚀"
    
    # Przykład działania w JavaScript
    js_example = lambda: "Kod JavaScript uruchomiony 🌐"
    
    # Wywołanie funkcji
    print(python_example())
    print(js_example())

create_multilingual_code()curl --header "X-GitHub-Api-Version:2022-11-28" https://api.github.com/zenhttps://[hostname]/stafftools/users/[old_username]/adminprogrammatic_access_type[
  "image/bmp",
  "image/cgm",
  "image/g3fax",
  "image/gif",
  "image/ief",
  "image/jp2",
  "image/jpeg",
  "image/jpg",
  "image/pict",
  "image/png",
  "image/prs.btif",
  "image/svg+xml",
  "image/tiff",
  "image/vnd.adobe.photoshop",
  "image/vnd.djvu",
  "image/vnd.dwg",
  "image/vnd.dxf",
  "image/vnd.fastbidsheet",
  "image/vnd.fpx",
  "image/vnd.fst",
  "image/vnd.fujixerox.edmics-mmr",
  "image/vnd.fujixerox.edmics-rlc",
  "image/vnd.microsoft.icon",
  "image/vnd.ms-modi",
  "image/vnd.net-fpx",
  "image/vnd.wap.wbmp",
  "image/vnd.xiff",
  "image/webp",
  "image/x-cmu-raster",
  "image/x-cmx",
  "image/x-icon",
  "image/x-macpaint",
  "image/x-pcx",
  "image/x-pict",
  "image/x-portable-anymap",
  "image/x-portable-bitmap",
  "image/x-portable-graymap",
  "image/x-portable-pixmap",
  "image/x-quicktime",
  "image/x-rgb",
  "image/x-xbitmap",
  "image/x-xpixmap",
  "image/x-xwindowdump"
]import time
import os

def display_art_pattern(repeat=1, delay=0.5):
    # Definicja wzoru, który przesłałeś. Możesz go dowolnie modyfikować.
    art_pattern = (
        "±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++\n"
        "±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++\n"
        "♧±±+++++±±+++++++++++++++++++±±+++++±±++++++++++++++++++±±+++++±±+++++++++++++++++++\n"
        "±±+++++±±++++++++++++++++++++±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++\n"
        "±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++\n"
        "±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++♧±±+++++±±+++++++++++++++++++\n"
        "±±+++++±±+++++++++++++++++++±±+++++±±+++++++++++++++++++±±+++++±±++++++++++++++++++++"
    )
    
    for _ in range(repeat):
        # Opcjonalnie czyścimy ekran, aby uzyskać efekt animacji
        os.system('cls' if os.name == 'nt' else 'clear')
        print(art_pattern)
        time.sleep(delay)

# Przykład użycia: wyświetlenie wzoru 5 razy z półsekundową przerwą
display_art_pattern(repeat=5, delay=0.5)github://com.github.android/oauth?browser_session_id=6bd3044de130ac8a8d0952e15d8c7fdf1745d3023d7feb672f4deb6fa1385c3d&code=8f2062402049932b1120&state=JWlTxu_NJCBIoy7BHxNtKw{
  "access_token": "accesstoken",
  "expires_in": "28800",
  "refresh_token": "r1.refreshme",
  "refresh_token_expires_in": "15811200",
  "scope": "",
  "token_type": "bearer"
}{
  "1": "Route %s used \"connection\" inside a function cached with \"unstable_cache(...)\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "2": "%sused %s. \\`searchParams\\` should be awaited before using its properties. The following properties were not available through enumeration because they conflict with builtin or well-known property names: %s. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "3": "The expire option must be a number of seconds.",
  "4": "Invariant: routeModule should be configured when rendering pages",
  "5": "[internal]",
  "6": "Invariant: logErrorWithOriginalStack can only be called on the development server",
  "7": "Route %s used \"%s\" during render which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
  "8": "No 'cssModules' option was found for the next-flight-css-loader plugin.",
  "9": "Invariant: Unexpected template variable %s",
  "10": "The router state header was sent but could not be parsed.",
  "11": "getStaticPaths with \"fallback: blocking\" cannot be used with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "12": "Route did not complete loading: %s",
  "13": "`turbo.startTurbopackTraceServer` is not supported by the wasm bindings.",
  "14": "Invariant: null responses cannot be streamed",
  "15": "Error for page %s: %s",
  "16": "Request failed with status %s.",
  "17": "Unknown cacheLife profile \"%s\" is not configured in next.config.js\\nDid you mean \"%s\" without the spaces?",
  "18": "Span has already ended",
  "19": "Unexpected server data: missing bootstrap script.",
  "20": "invalid response %s",
  "21": "can't decode empty hex",
  "22": "The provided export path '%s' doesn't match the '%s' page.\\nRead more: https://nextjs.org/docs/messages/export-path-mismatch",
  "23": "Image with src \"%s\" cannot end with a space or control character. Use src.trimEnd() to remove it or encodeURIComponent(src) to keep it.",
  "24": "Invalid revalidate configuration provided: %s < 1",
  "25": "The \"modules.namedExport\" option requires the \"modules.exportLocalsConvention\" option to be \"camelCaseOnly\"",
  "26": "Invalid flags should be run as node detached-flush dev ./path-to/project",
  "27": "NodeModuleLoader is not supported in edge runtime.",
  "28": "Invariant: Unexpected injection %s",
  "29": "Specified images.remotePatterns should be an Array received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config",
  "30": "You cannot have two parallel pages that resolve to the same path. Please check %s and %s. Refer to the route group docs for more information: https://nextjs.org/docs/app/building-your-application/routing/route-groups",
  "31": "expected appBuildManifest with an \"app\" pageType",
  "32": "invariant: unexpected cachedResponse of kind fetch in response cache",
  "33": "invariant: getServerSideProps did not return valid props. Please report this.",
  "34": "Invariant: Couldn't find action module ID from module map.",
  "35": "Turbopack build failed with %s issues:\\n%s",
  "36": "source-map information is not available at url() declaration %s",
  "37": "To use middleware you must provide a `hostname` and `port` to the Next.js Server",
  "38": "API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: \"edge\"` instead: https://nextjs.org/docs/api-routes/edge-api-routes",
  "39": "\\`%s\\` cannot be called inside \"use cache\". Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/messages/next-request-in-use-cache",
  "40": "Extra keys returned from getStaticPaths in %s (%s) %s",
  "41": "Specified basePath should not end with /, found \"%s\"",
  "42": "Dynamic WASM code generation ('WebAssembly.instantiate' with a buffer parameter) not allowed in Edge Runtime.\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation",
  "43": "Method not implemented.",
  "44": "Page \"%s\" cannot use both \\`export const runtime = 'edge'\\` and export \\`generateStaticParams\\`.",
  "45": "Specified pageExtensions is an empty array. Please update it with the relevant extensions or remove it.",
  "46": "Using client components is not allowed in this environment.",
  "47": "The default export is not a React Component in \"%s/%s\"",
  "48": "It's currently unsupported to use \"export *\" in a client boundary. Please use named exports instead.",
  "49": "Module `sharp` not found. Please run `npm install --cpu=wasm32 sharp` to install it.",
  "50": "An object should only be passed to the image component src parameter if it comes from a static image import. It must include height and width. Received %s",
  "51": "invariant: progress total can not be zero",
  "52": "`after()`: Argument must be a promise or a function",
  "53": "Invalid \"devIndicator.buildActivityPosition\" provided, expected one of %s, received %s",
  "54": "Method not implemented",
  "55": "Module \"%s\" does not export a routeModule.",
  "56": "Invariant: PPR cannot be enabled in export mode",
  "57": "invariant: failed to render error page",
  "58": "invariant expected layout router to be mounted",
  "59": "Invariant revalidate: 0 can not be passed to unstable_cache(), must be \"false\" or \"> 0\" %s",
  "60": "Middleware is not supported in minimal mode. Please remove the `NEXT_MINIMAL` environment variable.",
  "61": "Unexpected action %s",
  "62": "missing required error components",
  "63": "URL is malformed \"%s\". Please use only absolute URLs - https://nextjs.org/docs/messages/middleware-relative-urls",
  "64": "invariant: cache entry required but not generated",
  "65": "Failed to parse src \"%s\" on \\`next/image\\`, if using relative image it must start with a leading slash \"/\" or be an absolute URL (http:// or https://)",
  "66": "Unexpected route kind %s",
  "67": "Missing encryption key for Server Action. This is a bug in Next.js",
  "68": "Image with src \"%s\" has invalid \"width\" property. Expected a numeric value in pixels but received \"%s\".",
  "69": "<Html> should not be imported outside of pages/_document.\\nRead more: https://nextjs.org/docs/messages/no-document-import-in-page",
  "70": "Specified assetPrefix is not a string, found type \"%s\" https://nextjs.org/docs/messages/invalid-assetprefix",
  "71": "\\`%s\\` cannot be called inside unstable_cache. Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "72": "webpack config.resolve.alias was incorrectly overridden. https://nextjs.org/docs/messages/invalid-resolve-alias",
  "73": "Specified i18n.locales contains invalid values (%s), locales must be valid locale tags provided as strings e.g. \"en-US\".\\nSee here for list of valid language sub-tags: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
  "74": "assetPrefix must start with a leading slash or be an absolute URL(http:// or https://)",
  "75": "Image with src \"%s\" has both \"fill\" and \"style.width\" properties. Images with \"fill\" always use width 100% - it cannot be modified.",
  "76": "Failed to load script: %s",
  "77": "The server has not been instantiated properly. https://nextjs.org/docs/messages/invalid-server-options",
  "78": "expected \"app\" manifest data with an \"app\" pageType",
  "79": "Invalid %s header",
  "80": "Failed to load the `babel-plugin-react-compiler`. It is required to use the React Compiler. Please install it.",
  "81": "Node.js binary module ./%s is not supported in the browser. Please only use the module on server side",
  "82": "Invalid Server Actions request.",
  "83": "Invariant: dynamic responses cannot be unchunked. This is a bug in Next.js",
  "84": "Invalid usage of next/script. Did you forget to include a src attribute or an inline script? https://nextjs.org/docs/messages/invalid-script",
  "85": "Invalid \\`paths\\` value returned from getStaticPaths in %s.\\n\\`paths\\` must be an array of strings or objects of shape { params: [key: string]: string }",
  "86": "Invariant: Expected to inject all injections, found %s",
  "87": "Invariant: Unexpected optional import %s",
  "88": "Failed to set Next.js data cache, items over 2MB can not be cached (%s bytes)",
  "89": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config.",
  "90": "Route %s used \"cookies\" inside \"after(...)\". This is not supported. If you need this data inside an \"after\" callback, use \"cookies\" outside of the callback. See more info here: https://nextjs.org/docs/canary/app/api-reference/functions/after",
  "91": "Image with src \"%s\" has \"placeholder='blur'\" property but is missing the \"blurDataURL\" property.\n          Possible solutions:\n            - Add a \"blurDataURL\" property, the contents should be a small Data URL to represent the image\n            - Change the \"src\" property to a static import with one of the supported file types: %s (animated images not supported)\n            - Remove the \"placeholder\" property, effectively no blur effect\n          Read more: https://nextjs.org/docs/messages/placeholder-blur-data-url",
  "92": "Failed to initialize render server",
  "93": "`after()` will not work correctly, because `waitUntil` is not available in the current environment.",
  "94": "An error occurred while loading the instrumentation hook",
  "95": "Invariant: previewProps missing previewModeId this should never happen",
  "96": "cacheLife() can only be called during App Router rendering at the moment.",
  "97": "Specified basePath /. basePath has to be either an empty string or a path prefix\"",
  "98": "Image with src \"%s\" has both \"width\" and \"fill\" properties. Only one should be used.",
  "99": "A Node.js API is used (%s) which is not supported in the Edge Runtime.\nLearn more: https://nextjs.org/docs/api-reference/edge-runtime",
  "100": "An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
  "101": "Image with src \"%s\" has invalid \"width\" or \"height\" property. These should be numeric values.",
  "102": "Server Actions Size Limit must be a valid number or filesize format larger than 1MB: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit",
  "103": "The \"parallelServerBuildTraces\" and \"parallelServerCompiles\" options may only be used when build workers can be used. Read more: https://nextjs.org/docs/messages/parallel-build-without-worker",
  "104": "If providing both the stale and expire options, the expire option must be greater than the stale option.The expire option indicates how many seconds from the start until it can no longer be used.",
  "105": "The \"modules.namedExport\" option requires the \"esModules\" option to be enabled",
  "106": "Pass `Infinity` instead of `false` if you do not want to revalidate by time.",
  "107": "Specified basePath has to start with a /, found \"%s\"",
  "108": "Cannot tee a ReactServerResult that has already been consumed",
  "109": "Failed to create a proxy server",
  "110": "Specified pageExtensions is not an array of strings, found \"%s\" of type \"%s\". Please update this config or remove it.",
  "111": "request failed with status %s",
  "112": "Invalid cacheLife() option. Either pass a profile name or object.",
  "113": "Route %s used \"connection\" inside \"use cache\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
  "114": "Invariant: unexpected marker",
  "115": "Unknown source map type for %s: %s.",
  "116": "Invariant: Unknown request type.",
  "117": "Image with src \"%s\" has both \"height\" and \"fill\" properties. Only one should be used.",
  "118": "Invariant cant propagate server field, no app initialized",
  "119": "The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.",
  "120": "Specified images.localPatterns should be an Array received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config",
  "121": "request.headers must be an instance of Headers",
  "122": "The Middleware \"%s\" must export a \\`middleware\\` or a \\`default\\` function",
  "123": "The /404 page can not return notFound in \"getStaticProps\", please remove it to continue!",
  "124": "next build doesn't support turbopack yet",
  "125": "Invariant: url can not be undefined",
  "126": "Failed to load static props",
  "127": "\\`pages%s\\` %s",
  "128": "Route %s used %s without first calling \\`await connection()\\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers",
  "129": "Route %s used \"headers\" inside a function cached with \"unstable_cache(...)\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"headers\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "130": "Using a self signed certificate is only supported with `next dev`.",
  "131": "invariant: getStaticProps did not return valid props. Please report this.",
  "132": "Invariant: App Route Route Modules cannot be used in the edge runtime",
  "133": "Certificate files not found",
  "134": "Page changed from static to dynamic at runtime %s%s\\nsee more here https://nextjs.org/docs/messages/app-static-to-dynamic-error",
  "135": "Route %s used \"%s\" inside a function cached with \"unstable_cache(...)\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"%s\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "136": "\\`pages/404\\` %s",
  "137": "%s be used within %s.",
  "138": "Expected webpack publicPath to be a string when using App Router. To customize where static assets are loaded from, use the `assetPrefix` option in next.config.js. If you are customizing your webpack config please make sure you are not modifying or removing the publicPath configuration option",
  "139": "Unknown cacheLife profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  experimental: {\n    cacheLife: {\n      \"%s\": ...\\n    }\n  }\n}",
  "140": "Unknown StyledString type",
  "141": "Can't resolve main package.json file",
  "142": "Specified pageExtensions is not an array of strings, found \"%s\". Please update this config or remove it.",
  "143": "Unsupported platform: %s",
  "144": "The router state header was too large.",
  "145": "request failed with empty body",
  "146": "> Couldn't find any `pages` or `app` directory. Please create one under the project root",
  "147": "Proxy request aborted [%s %s]",
  "148": "Proxy request failed: %s",
  "149": "Detected a three-dot character ('…') at ('%s'). Did you mean ('...')?",
  "150": "Specified i18n should be an object received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
  "151": "Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation",
  "152": "Invariant: Expected to inject all imports, missing %s in template",
  "153": "Invariant: static responses cannot be streamed",
  "154": "Cannot parse form action \"%s\" as a URL",
  "155": "Invalid urlPath provided to revalidate(), must be a path e.g. /blog/post-1, received %s",
  "156": "Invariant: basePath must be set and cannot be \"/\"",
  "157": "unrecognized HMR message \"%s\"",
  "158": "Invariant: page postponed without PPR being enabled",
  "159": "Route %s used \"cookies\" inside a function cached with \"unstable_cache(...)\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"cookies\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "160": "Unexpected middleware effect on /404",
  "161": "invariant: invalid relative URL, router received %s",
  "162": "invariant image optimizer cache was not initialized",
  "163": "A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received '%s' for %s",
  "164": "The Edge Function \"pages%s\" must export a \\`default\\` function",
  "165": "images.loaderFile detected but the file is missing default export.\nRead more: https://nextjs.org/docs/messages/invalid-images-config",
  "166": "webpack build failed: found page without a React Component as default export in pages/%s\\n\\nSee https://nextjs.org/docs/messages/page-without-valid-component for more info.",
  "167": "Invariant: unexpected cachedResponse of kind fetch in response cache",
  "168": "%s from Minifier\\n%s",
  "169": "An unexpected Turbopack error occurred. Please see the output of `next dev` for more details.",
  "170": "Invalid escape character at the end.",
  "171": "invariant: invalid previewModeId",
  "172": "The key \"%s\" under \"env\" in %s is not allowed. https://nextjs.org/docs/messages/env-key-not-allowed",
  "173": "Specified images should be an object received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config",
  "174": "Failed to fetch registry info for %s, got status %s",
  "175": "The packages specified in the 'transpilePackages' conflict with the 'serverExternalPackages': %s",
  "176": "Invariant: required internal revalidate method not passed to api-utils",
  "177": "Invalid response %s",
  "178": "Image with src \"%s\" cannot start with a space or control character. Use src.trimStart() to remove it or encodeURIComponent(src) to keep it.",
  "179": "cacheTag() can only be called inside a \"use cache\" function.",
  "180": "Route %s used \"%s\" inside \"use cache\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"%s\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
  "181": "Invalid revalidate value \"%s\" on \"%s\", must be a non-negative number or false",
  "182": "invalid cache value",
  "183": "failed to pipe response",
  "184": "Route %s used \"%s\" inside a \"use cache\" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
  "185": "Invalid URL",
  "186": "ImageResponse moved from \"next/server\" to \"next/og\" since Next.js 14, please import from \"next/og\" instead",
  "187": "Dynamic WASM code generation (e. g. 'WebAssembly.compile') not allowed in Edge Runtime.\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation",
  "188": "Invalid redirect object returned from %s for %s\\n%s\nSee more info here: https://nextjs.org/docs/messages/invalid-redirect-gssp",
  "189": "Route %s used \"connection\" inside \"after(...)\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual Request, but \"after(...)\" executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/canary/app/api-reference/functions/after",
  "190": "getStaticPaths is only allowed for dynamic SSG pages and was found on '%s'.\\nRead more: https://nextjs.org/docs/messages/non-dynamic-getstaticpaths-usage",
  "191": "Next Image Optimization requires %s to be provided. Make sure you pass them as props to the \\`next/image\\` component. Received: %s",
  "192": "Failed to load stylesheet: %s",
  "193": "Invariant: expected filename to exist in cache",
  "194": "Invalid Server Action payload: failed to decrypt.",
  "195": "notFound() is not allowed to use in root layout",
  "196": "Invariant: %s",
  "197": "Invariant: failed to get page data for %s",
  "198": "The experimental.allowDevelopmentBuild option requires NODE_ENV to be explicitly set to 'development'.",
  "199": "Invariant: Expected to replace all template variables, missing %s in template",
  "200": "Invalid \"experimental.cacheHandlers\" provided, expected an object e.g. { default: '/my-handler.js' }, received %s",
  "201": "missing mkcert binary",
  "202": "Failed to parse source map URL for %s.",
  "203": "Invariant: buildID is required",
  "204": "ISR cannot be used with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "205": "> Build directory is not writeable. https://nextjs.org/docs/messages/build-dir-not-writeable",
  "206": "Configuring Next.js via '%s' is not supported. Please replace the file with 'next.config.js', 'next.config.mjs', or 'next.config.ts'.",
  "207": "Expected config.httpAgentOptions to be an object",
  "208": "Expected incremental cache to exist. This is a bug in Next.js",
  "209": "Specified distDir is not a string, found type \"%s\"",
  "210": "Invalid interception route: %s. Cannot use (..) marker at the root level, use (.) instead.",
  "211": "Unterminated string",
  "212": "Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.\nLearn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor",
  "213": "getStaticPaths with \"fallback: true\" cannot be used with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "214": "Invariant: should handle all automatic implementable methods, got method: %s",
  "215": "A conflicting public file and page file was found for path %s https://nextjs.org/docs/messages/conflicting-public-file-page",
  "216": "parseBody is not implemented in the web runtime",
  "217": "Invariant: Expected relative import to start with \"next/\", found \"%s\"",
  "218": "Unable to find uri in \"%s\"",
  "219": "Image with src \"%s\" has both \"fill\" and \"style.position\" properties. Images with \"fill\" always use position absolute - it cannot be modified.",
  "220": "Invalid handler fields configured for \"experimental.cacheHandler\":\\n%s",
  "221": "Image with src \"%s\" has both \"priority\" and \"loading='lazy'\" properties. Only one should be used.",
  "222": "PrefixPathnameNormalizer: prefix \"%s\" should not end with a slash",
  "223": "Failed to parse source map %s.",
  "224": "The 'public' directory is reserved in Next.js and can not be set as the 'distDir'. https://nextjs.org/docs/messages/can-not-output-to-public",
  "225": "Failed to initialize render server \"middleware\"",
  "226": "%sused %s. \\`cookies()\\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "227": "Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js",
  "228": "Unexpected middleware effect on %s",
  "229": "Invariant: Missing `host` header from a forwarded Server Actions request.",
  "230": "Specified i18n.locales should be an Array received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
  "231": "Specified images.loader property (%s) also requires images.path property to be assigned to a URL prefix.\\nSee more info here: https://nextjs.org/docs/api-reference/next/legacy/image#loader-configuration",
  "232": "Cannot close a CloseController multiple times",
  "233": "'router' and 'Component' can not be returned in getInitialProps from _app.js https://nextjs.org/docs/messages/cant-override-next-props",
  "234": "Invalid src prop (%s) on \\`next/image\\`, hostname \"%s\" is not configured under images in your \\`next.config.js\\`\\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-host",
  "235": "Failed to parse \"%s\":\\n%s",
  "236": "The revalidate option must be a number of seconds.",
  "237": "Cannot prefetch '%s' because it cannot be converted to a URL.",
  "238": "Invariant: expected routes to have been loaded before match",
  "239": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside \"use cache\".",
  "240": "Invalid OpenGraph type: %s",
  "241": "invariant expected app router to be mounted",
  "242": "Invariant: page wasn't built",
  "243": "Failed to revalidate %s: %s",
  "244": "Invalid value returned from getStaticPaths in %s. Received %s %s",
  "245": "Invariant: expected compilation to finish before new matchers were added, possible missing await",
  "246": "The \\`fallback\\` key must be returned from getStaticPaths in %s.\\n%s",
  "247": "invalid hex: \\`%s%s\\`",
  "248": "Couldn't find a style target. This probably means that the value for the 'insert' parameter is invalid.",
  "249": "Route %s used \"%s\" inside \"use cache\". The enabled status of draftMode can be read in caches but you must not enable or disable draftMode inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
  "250": "You cannot have the same slug name \"%s\" repeat within a single dynamic path",
  "251": "Unknown cache handler: %s",
  "252": "%sused %s. \\`searchParams\\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "253": "cacheLife() can only be called inside a \"use cache\" function.",
  "254": "\\`%s\\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
  "255": "Image with src \"%s\" is missing \"loader\" prop.\\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader",
  "256": "Expected to use %s bindings (%s) for React but the current process is referencing '%s' from the %s bindings (%s). This is likely a bug in our integration of the Next.js server runtime.",
  "257": "Invalid fallback mode: %s",
  "258": "getStaticPaths is required for dynamic SSG pages and is missing for '%s'.\\nRead more: https://nextjs.org/docs/messages/invalid-getstaticpaths-value",
  "259": "Can't use lazyRenderAppPage in minimal mode",
  "260": "Invariant: invalid matchers for middleware %s",
  "261": "Invariant: response is null. This is a bug in Next.js",
  "262": "Route %s used \"%s\" inside a function cached with \"unstable_cache(...)\". The enabled status of draftMode can be read in caches but you must not enable or disable draftMode inside a cache. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
  "263": "Not a redirect error",
  "264": "Route %s used %s without first calling \\`await connection()\\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-request",
  "265": "%s %s",
  "266": "Invariant: static generation store missing in %s",
  "267": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment. %s",
  "268": "Farm is ended, no more calls can be done to it",
  "269": "Multiple children were passed to <Link> with \\`href\\` of \\`%s\\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children%s",
  "270": "Dynamic href \\`%s\\` found in <Link> while using the \\`/app\\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",
  "271": "Failed to prefetch: %s",
  "272": "Invalid interception route: %s. Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>",
  "273": "Conflicting public and page file%s found. https://nextjs.org/docs/messages/conflicting-public-file-page\\n%s",
  "274": "Invariant: expected to find identity in indexes map",
  "275": "Can't use lazyRenderPagesPage in minimal mode",
  "276": "Failed to load client build manifest",
  "277": "Invariant: null responses cannot be unchunked",
  "278": "Turbopack did not return any entrypoints",
  "279": "invariant: runMiddleware should not be called in minimal mode",
  "280": "%sused %s. \\`headers()\\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "281": "export const dynamic = \"force-dynamic\" on page \"%s\" cannot be used with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "282": "\"use cache\" cannot be used outside of App Router. Expected a WorkStore.",
  "283": "Segment \"%s\" exports \"dynamicParams: false\" but the param \"%s\" is missing from the generated route params.",
  "284": "Invariant: could not resolve page path for %s at %s",
  "285": "Invariant: attempted to hard navigate to the same URL %s %s",
  "286": "Attempted to handle request too many times %s",
  "287": "unstable_redirect has been renamed to redirect, please update the field to continue. Page: %s",
  "288": "Invalid fallback option: %s. Fallback option must be a string, null, undefined, or false.",
  "289": "The default export is not a React Component in page: \"%s\"",
  "290": "Invariant request handler was not setup",
  "291": "Segment names may not start with erroneous periods ('%s').",
  "292": "Unexpected error: extracting params from path failed but the regular expression matched",
  "293": "Invariant upgrade handler was not setup",
  "294": "Invariant: ensurePage can only be called on the development server",
  "295": "transformSync doesn't implement reading the file from filesystem",
  "296": "invalid hex: \\`%s\\`",
  "297": "cacheLifeProfiles should always be provided. This is a bug in Next.js.",
  "298": "Unknown action",
  "299": "Invariant: isDynamicPostpone misidentified a postpone reason. This is a bug in Next.js",
  "300": "Webpack config is undefined. You may have forgot to return properly from within the \"webpack\" method of your %s.\\nSee more info here https://nextjs.org/docs/messages/undefined-webpack-config",
  "301": "A required parameter (%s) was not provided as %s received %s in %s for %s",
  "302": "You cannot use both an required and optional catch-all route at the same level (\"[...%s]\" and \"%s\" ).",
  "303": "You cannot use both an optional and required catch-all route at the same level (\"[[...%s]]\" and \"%s\").",
  "304": "export const dynamic = \"force-static\"/export const revalidate not configured on route \"%s\" with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "305": "Expected span to be ended",
  "306": "Route name should start with a \"/\", got \"%s\"",
  "307": "Route %s used \"headers\" inside \"use cache\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"headers\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
  "308": "Invariant: expected a page response, got %s",
  "309": "Route %s used \"%s\" inside a function cached with \"unstable_cache(...)\" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
  "310": "%sused %s. \\`params\\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "311": "The stale option must be a number of seconds.",
  "312": "Build failed because of webpack errors",
  "313": "ESM packages (%s) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals",
  "314": "A page's revalidate option can not be less than or equal to zero for %s. A revalidate option of zero means to revalidate after _every_ request, and implies stale data cannot be tolerated.\\n\\nTo never revalidate, you can set revalidate to \\`false\\` (only ran once at build-time).\\nTo revalidate as soon as possible, you can set the value to \\`1\\`.",
  "315": "Component rendered inside next/link has to pass click event to \"onClick\" prop.",
  "316": "predicate must return an absolute path or the result of calling next()",
  "317": "Invariant: invalid postponed state %s",
  "318": "Route Cancelled",
  "319": "unknown route type %s for %s",
  "320": "Invariant missing routerServerHandler",
  "321": "Failed to parse source map for %s.",
  "322": "Failed prop type: The prop \\`%s\\` expects a %s in \\`<Link>\\`, but got \\`%s\\` instead.%s",
  "323": "No children were passed to <Link> with \\`href\\` of \\`%s\\` but one child is required https://nextjs.org/docs/messages/link-no-children",
  "324": "failed to write chunk to response",
  "325": "Additional keys were returned from \\`getStaticPaths\\` in page \"%s\". URL Parameters intended for this dynamic route must be nested under the \\`params\\` key, i.e.:\\n\\n\\treturn { params: { %s } }\\n\\nKeys that need to be moved: %s.\\n",
  "326": "Your custom PostCSS configuration may not export a function. Please export a plain object instead.\\nRead more: https://nextjs.org/docs/messages/postcss-function",
  "327": "`css.lightning.transformStyleAttr` is not supported by the wasm bindings.",
  "328": "No response is returned from route handler '%s'. Ensure you return a \\`Response\\` or a \\`NextResponse\\` in all branches of your handler.",
  "329": "Specified basePath is not a string, found type \"%s\"",
  "330": "invalid address from server: %s",
  "331": "Manifest file is empty",
  "332": "To use a multi-match in the destination you must add \\`*\\` at the end of the param name to signify it should repeat. https://nextjs.org/docs/messages/invalid-multi-match",
  "333": "`css.lightning.transform` is not supported by the wasm bindings.",
  "334": "%s from Minifier\\n%s\\n%s",
  "335": "Edge function did not return a response",
  "336": "Invariant: missing request body.",
  "337": "invariant: invalid previewModeEncryptionKey",
  "338": "type system invariant violation",
  "339": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
  "340": "You cannot use different slug names for the same dynamic path ('%s' !== '%s').",
  "341": "Unknown \"loader\" found in \"next.config.js\". Expected: %s. Received: %s",
  "342": "%s%s",
  "343": "No directory access",
  "344": "It looks like you didn't end your @import statement correctly. Child nodes are attached to it.",
  "345": "Failed to write turborepo access trace file",
  "346": "Invalid assetPrefix provided. Original error: %s",
  "347": "%sRead more: https://nextjs.org/docs/messages/%s",
  "348": "Invariant: Unsupported NextRequest type",
  "349": "invariant revalidate must be a number for image-cache",
  "350": "Your custom PostCSS configuration must export a \\`plugins\\` key.",
  "351": "Route %s used \"%s\" inside \\`after\\`. The enabled status of draftMode can be read inside \\`after\\` but you cannot enable or disable draftMode. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
  "352": "could not get asset: %s",
  "353": "No default cacheLife profile.",
  "354": "%s from Minifier\\n%s [%s:%s,%s]%s",
  "355": "A \"use server\" file can only export async functions, found %s.\\nRead more: https://nextjs.org/docs/messages/invalid-use-server-value",
  "356": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config.",
  "357": "Taint can only be used with the taint flag.",
  "358": "prepare() must be called before performing this operation",
  "359": "getStaticPaths can only be used with dynamic pages, not '%s'.\\nLearn more: https://nextjs.org/docs/routing/dynamic-routes",
  "360": "Image with src \"%s\" has invalid \"loading\" property. Provided \"%s\" should be one of %s.",
  "361": "Invalid locale returned from getStaticPaths for %s, the locale %s is not specified in %s",
  "362": "Invariant: server actions can't be handled during static rendering",
  "363": "Failed to parse src \"%s\" on \\`next/image\\`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)",
  "364": "failed to resolve %s from %s",
  "365": "Route %s errored during the prospective render. These errors are normally ignored and may not prevent the route from prerendering but are logged here because build debugging is enabled.\n          \nOriginal Error: %s",
  "366": "Invariant: Expected to replace at least one import",
  "367": "invariant: Missing request body.",
  "368": "Cannot subscribe to a closed CloseController",
  "369": "invariant attempted to set non-image to image-cache",
  "370": "Route %s used \"headers\" inside \"after(...)\". This is not supported. If you need this data inside an \"after\" callback, use \"headers\" outside of the callback. See more info here: https://nextjs.org/docs/canary/app/api-reference/functions/after",
  "371": "Invariant might be excluded but missing source",
  "372": "getServerSideProps cannot be used with \"output: export\". See more info here: https://nextjs.org/docs/advanced-features/static-html-export",
  "373": "No Stats from webpack",
  "374": "Image with src \"%s\" has \"placeholder='blur'\" property but is missing the \"blurDataURL\" property.\n        Possible solutions:\n          - Add a \"blurDataURL\" property, the contents should be a small Data URL to represent the image\n          - Change the \"src\" property to a static import with one of the supported file types: %s (animated images not supported)\n          - Remove the \"placeholder\" property, effectively no blur effect\n        Read more: https://nextjs.org/docs/messages/placeholder-blur-data-url",
  "375": "Invariant: Expected postponed to be undefined",
  "376": "mis-matched route type: isApp && page for %s",
  "377": "NextResponse.rewrite() was used in a app route handler, this is not currently supported. Please remove the invocation to continue.",
  "378": "\"next start\" does not work with \"output: export\" configuration. Use \"npx serve@latest out\" instead.",
  "379": "Copy to clipboard is not supported in this browser",
  "380": "%sused %s. \\`draftMode()\\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
  "381": "Unknown dynamic param type",
  "382": "Page %s does not export a default function.",
  "383": "Invalid href: \"%s\" and as: \"%s\", received relative href and external as\\nSee more info: https://nextjs.org/docs/messages/invalid-relative-url-external-as",
  "384": "Static generation failed due to dynamic usage on %s, reason: %s",
  "385": "Invariant: Expected to inject all injections, missing %s in template…